### PR TITLE
Lazy load configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 We follow [Semantic Versioning](http://semver.org/) as a way of measuring stability of an update. This
 means we will never make a backwards-incompatible change within a major version of the project.
 
+## _[UNRELEASED]_
+
+- Lazy loads redis connection to only when needed (@thelonelyghost)
+- Redis connection reads from environment variable `REDIS_CONNECTION_URL`, defaulting to localhost on default redis port (@thelonelyghost)
+
 ## v0.2.0
 
 - Added heartbeat web service to check status of a bot (by @itsthejoker)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ When initializing the new bot, all you have to do is call `build_bot()` and then
 ## Example
 
 ```python
+from tor_core.config import config
 from tor_core.initialize import build_bot
 from tor_core.helpers import run_until_dead
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ The important parts are two functions that assist with setting up and running th
 
 When initializing the new bot, all you have to do is call `build_bot()` and then pass your runtime function into `run_until_dead()`. When `run_until_dead()` returns, everything necessary has been processed to allow the bot to die. Set `run_until_dead()` as the last line under `if __name__ == '__main__'` and the bot will exit cleanly after this returns.
 
+## Example
+
+```python
+from tor_core.initialize import build_bot
+from tor_core.helpers import run_until_dead
+
+
+def do_your_thing():
+    # Do stuff here
+
+    if config.some_configuration == 'value':
+        pass  # Do a thing
+    else:
+        pass  # Do a different thing
+
+
+def main():
+    build_bot('tor_main', __version__, full_name='TranscribersOfReddit')
+    config.some_configuration = 'value'
+    run_until_dead(do_your_thing)
+
+
+if __name__ == '__main__':
+    main()
+```
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import codecs
 import os
 import sys

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,7 @@
 import pytest
 
+import redis.exceptions
+
 from tor_core.config import config as SITE_CONFIG
 
 
@@ -42,3 +44,16 @@ def test_config_structure():
 
     assert type(SITE_CONFIG.slack_api_url) is str or \
         SITE_CONFIG.slack_api_url is None
+
+
+def test_redis_config_property():
+    try:
+        assert SITE_CONFIG.redis, 'Does not observe lazy loader'
+    except redis.exceptions.ConnectionError:
+        pass
+
+    # Check stubbing with derivations of BaseException
+    type(SITE_CONFIG).redis = property(lambda x: (_ for _ in ()).throw(NotImplementedError('Redis was disabled')))
+
+    with pytest.raises(NotImplementedError):
+        SITE_CONFIG.redis.ping()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,15 +5,15 @@ from tor_core.config import config as SITE_CONFIG
 
 @pytest.mark.skip
 def test_read_secrets_from_filesystem():
-    '''Secret data has been read from the filesystem
-    '''
+    """Secret data has been read from the filesystem
+    """
     assert SITE_CONFIG.bugsnag_api_key is not None
     assert SITE_CONFIG.slack_api_url is not None
 
 
 def test_config_structure():
-    '''Config singleton is structured as expected
-    '''
+    """Config singleton is structured as expected
+    """
     assert type(SITE_CONFIG.video_domains) is list
     assert type(SITE_CONFIG.audio_domains) is list
     assert type(SITE_CONFIG.image_domains) is list

--- a/tor_core/config.py
+++ b/tor_core/config.py
@@ -35,12 +35,12 @@ class cached_property(object):
     """
 
     # implementation detail: this property is implemented as non-data
-    # descriptor.  non-data descriptors are only invoked if there is
-    # no entry with the same name in the instance's __dict__.
-    # this allows us to completely get rid of the access function call
-    # overhead.  If one choses to invoke __get__ by hand the property
-    # will still work as expected because the lookup logic is replicated
-    # in __get__ for manual invocation.
+    # descriptor. non-data descriptors are only invoked if there is no
+    # entry with the same name in the instance's __dict__. this allows
+    # us to completely get rid of the access function call overhead. If
+    # one choses to invoke __get__ by hand the property will still work
+    # as expected because the lookup logic is replicated in __get__ for
+    # manual invocation.
 
     def __init__(self, func, name=None, doc=None):
         self.__name__ = name or func.__name__
@@ -198,8 +198,8 @@ class Config(object):
 
         try:
             url = os.environ.get('REDIS_CONNECTION_URL',
-                                 'redis://localhost:6379')
-            conn = StrictRedis.from_url(url, db=0)
+                                 'redis://localhost:6379/0')
+            conn = StrictRedis.from_url(url)
             conn.ping()
         except redis.exceptions.ConnectionError:
             logging.fatal("Redis server is not running")

--- a/tor_core/initialize.py
+++ b/tor_core/initialize.py
@@ -42,8 +42,8 @@ def configure_redis():
     :return: object: the active Redis object.
     """
     try:
-        url = os.getenv('REDIS_CONNECTION_URL', 'redis://localhost:6379')
-        redis_server = redis.StrictRedis.from_url(url, db=0)
+        url = os.getenv('REDIS_CONNECTION_URL', 'redis://localhost:6379/0')
+        redis_server = redis.StrictRedis.from_url(url)
         redis_server.ping()
     except redis.exceptions.ConnectionError:
         logging.fatal("Redis server is not running! Exiting!")

--- a/tor_core/initialize.py
+++ b/tor_core/initialize.py
@@ -278,11 +278,9 @@ def build_bot(
     config.heartbeat_logging = heartbeat_logging
     configure_logging(config, log_name=log_name)
 
-    if require_redis:
-        config.redis = configure_redis()
-    else:
+    if not require_redis:
         # I'm sorry
-        config.redis = lambda: (_ for _ in ()).throw(NotImplementedError('Redis was disabled during building!'))
+        type(config).redis = property(lambda x: (_ for _ in ()).throw(NotImplementedError('Redis was disabled during building!')))
 
     config.tor = configure_tor(config)
     initialize(config)

--- a/tor_core/initialize.py
+++ b/tor_core/initialize.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import random
 import sys
 
@@ -41,7 +42,8 @@ def configure_redis():
     :return: object: the active Redis object.
     """
     try:
-        redis_server = redis.StrictRedis(host='localhost', port=6379, db=0)
+        url = os.getenv('REDIS_CONNECTION_URL', 'redis://localhost:6379')
+        redis_server = redis.StrictRedis.from_url(url, db=0)
         redis_server.ping()
     except redis.exceptions.ConnectionError:
         logging.fatal("Redis server is not running! Exiting!")

--- a/tor_core/initialize.py
+++ b/tor_core/initialize.py
@@ -282,13 +282,11 @@ def build_bot(
         # I'm sorry
         type(config).redis = property(lambda x: (_ for _ in ()).throw(NotImplementedError('Redis was disabled during building!')))
 
-    config.tor = configure_tor(config)
     initialize(config)
 
     if require_redis:
         # we want this to run after the config object is created
         # and for this version, heartbeat requires db access
-        config.heartbeat_port = get_heartbeat_port(config)
         configure_heartbeat(config)
 
     logging.info('Bot built and initialized!')


### PR DESCRIPTION
This adds some more lazy loading instead of front-loading all things configuration for our growing bots.

Among other things, this lazy loads the Redis connection (`config.redis`), the subreddit connection (`config.tor`), and the heartbeat port (`config.heartbeat_port`). This also allows easier stubbing of the connection such that it doesn't have to occur during initialization of the object, only before it is used the first time. This should help with testability.

Also it adds in testing for the redis connection and allowing it to be stubbed.