### PR TITLE
Only log to console

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+ignore =
+    # F403: unable to detect undefined names with `from x import *`
+    F403,
+    # F405: undefined or may be defined from `from foo imports *` imports
+    F405
+exclude =
+  # No need to go through the VCS directories
+  .git,.svn,.bzr,.hg,CVS,.tox,
+  # nor cache entries
+  *.pyc,__pycache__,
+  # nor install directories
+  *.egg-info,.eggs,.direnv,
+statistics = True
+max-line-length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ praw.ini
 .eggs
 .cache/
 .idea/
+.coverage
 __pycache__/
 heartbeat.port
 *.key

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean all test
 
-all: test clean
+all: develop test clean
 	@true
 
 clean:
@@ -9,4 +9,10 @@ clean:
 	@find . -regex '.+/__pycache__$$' -exec rm -rf {} \; -prune
 
 test: clean
-	@python setup.py test
+	@python3 setup.py test
+
+install: clean
+	@python3 -m pip install --process-dependency-links -e .
+
+develop: clean
+	@python3 -m pip install --process-dependency-links -e .[dev]

--- a/tor_core/admin_commands.py
+++ b/tor_core/admin_commands.py
@@ -1,28 +1,2 @@
-import logging
-import os
-import random
-import sys
-
-from tor_core.helpers import _
-
-import sh
-
-
 def from_moderator(reply, config):
     return reply.author in config.tor_mods
-
-
-# XXX: THIS DOES NOT WORK
-# but I'm including it anyways because it will be useful if we fix it.
-def update_and_restart(reply, config):
-    if not from_moderator(reply, config):
-
-        reply.reply(_(random.choice(config.no_gifs)))
-        logging.info(
-            f'{reply.author.name} just issued update. No.'
-        )
-    else:
-        # update from repo
-        sh.git.pull("origin", "master")
-        # restart own process
-        os.execl(sys.executable, sys.executable, *sys.argv)

--- a/tor_core/initialize.py
+++ b/tor_core/initialize.py
@@ -59,19 +59,10 @@ def configure_redis():
 def configure_logging(config, log_name='transcribersofreddit.log'):
     logging.basicConfig(
         level=logging.INFO,
-        format='[%(asctime)s] - [%(levelname)s] - [%(funcName)s] - %(message)s',
-        datefmt='%m/%d/%Y %I:%M:%S %p',
-        filename=log_name
+        format='%(levelname)s | %(funcName)s | %(message)s',
+        datefmt='%Y-%m-%dT%H:%M:%S',
     )
-    console = logging.StreamHandler()
-    console.setLevel(logging.INFO)
-    formatter = logging.Formatter(
-        '[%(asctime)s] - [%(funcName)s] - %(message)s')
-    # tell the handler to use this format
-    console.setFormatter(formatter)
 
-    # add the handlers to the root logger
-    logging.getLogger('').addHandler(console)
     # will intercept anything error level or above
     if config.bugsnag_api_key:
         bs_handler = BugsnagHandler()


### PR DESCRIPTION
This includes some general housekeeping changes, such as updating the Makefile, pruning some dead code, and adding a basic flake8 configuration that coincides with our pylint standards. The meat of this PR is actually about the logging.

On our server we use systemd to run the bots, which pipes stdout and stderr into a syslog-like process called journalctl. The journalctl command already adds a timestamp, a user-defined tag (e.g., `tor_ocr`), and a pid to each log entry along with the line in stdout as the message.

This PR is to remove a lot of the noise from the logs and to only log to the console, so we don't have to worry about rotating the log files.