### PR TITLE
update clean_id method in preparation for API change

### DIFF
--- a/tor_core/helpers.py
+++ b/tor_core/helpers.py
@@ -146,10 +146,16 @@ def clean_id(post_id):
     `t3_`, but this doesn't always work for getting a new object. This
     method removes those prefixes and returns the rest.
 
+    Sometimes we might be working with an ID string that's already clean;
+    just return that sucker.
+
     :param post_id: String. Post fullname (ID)
     :return: String. Post fullname minus the first three characters.
     """
-    return post_id[post_id.index('_') + 1:]
+    try:
+        return post_id[post_id.index('_') + 1:]
+    except ValueError:
+        return post_id
 
 
 def get_parent_post_id(post, r):


### PR DESCRIPTION
This is a simple fix to maintain compatibility with the OCR bot -- should be safe to deploy as it stands. We're changing how IDs are passed from u/ToR to u/transcribot, and since transcribot tries to clean the ID and it's already clean, then we want to be able to catch that and let it pass quietly. This specific change allows us to deploy the tor_core without affecting other functionality while the rest of the PRs are being prepared.

Signed-off-by: Joe Kaufeld <joe.kaufeld@gmail.com>